### PR TITLE
Read-only git URL

### DIFF
--- a/smart.json
+++ b/smart.json
@@ -4,5 +4,5 @@
   "homepage": "https://github.com/sachag/meteor-spin",
   "author": "Sacha Greif",
   "version": "0.1.0",
-  "git": "https://github.com/sachag/meteor-spin.git"
+  "git": "git://github.com/SachaG/meteor-spin.git"
 }


### PR DESCRIPTION
Should fix the glitch where Github asks for username/password on a public repo.
