### PR TITLE
Update to meteor 1.1

### DIFF
--- a/lib/spinner.js
+++ b/lib/spinner.js
@@ -1,13 +1,15 @@
-Template.spinner.rendered = function () {
+Template.spinner.onRendered(function(){
   var options = _.extend({}, Meteor.Spinner.options, this.data);
 
   this.spinner = new Spinner(options);
   this.spinner.spin(this.firstNode);
-};
+});
 
-Template.spinner.destroyed = function () {
+
+Template.spinner.onDestroyed(function(){
   this.spinner && this.spinner.stop();
-};
+});
+
 
 Meteor.Spinner = {
   options: {


### PR DESCRIPTION
Renaming `rendered` and `destroyed` functions to `onRendered` and `onCreated` from new Meteor 1.1 Version