### PR TITLE
Update version of Spin.js.

### DIFF
--- a/package.js
+++ b/package.js
@@ -6,7 +6,7 @@ Package.describe({
 });
 
 Npm.depends({
-  "spin.js": "2.0.1"
+  "spin.js": "2.3.1"
 });
 
 Package.onUse(function (api, where) {


### PR DESCRIPTION
The 2.0.1 version of Spin.js doesn't work on the current version of Safari (the spinner doesn't spin); the current 2.3.1 version fixes this problem.